### PR TITLE
Add API endpoints to bypass front end

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,9 @@ RUN --mount=source=.git,target=.git,type=bind \
 #    --mount=source=scraibe_webui,target=scraibe_webui,type=bind \
     pip install --no-cache-dir ./src
 
+# Install FastAPI and Uvicorn
+RUN pip install fastapi uvicorn
+
 # Expose port
 EXPOSE 7860
 # Run the application

--- a/README.md
+++ b/README.md
@@ -82,3 +82,44 @@ ScrAIbe-WebUI is proudly open source and licensed under the GPL-3.0 license. Thi
 ---
 
 Join us in making ScrAIbe-WebUI even better! 🚀
+
+## API Endpoints
+
+ScrAIbe-WebUI now includes API endpoints to bypass the front end and programmatically call the backend to get transcriptions. The API is built using FastAPI and provides the following endpoints:
+
+### Transcribe Audio
+
+Endpoint: `/api/transcribe`
+
+Method: `POST`
+
+Description: Receives an audio file and returns the transcription.
+
+#### Request
+
+- `file`: The audio file to be transcribed.
+- `task`: The transcription task to be performed. Options are "Auto Transcribe", "Transcribe", and "Diarisation".
+- `num_speakers`: (Optional) The number of speakers in the audio file.
+- `translate`: (Optional) Whether to translate the transcription to English.
+- `language`: (Optional) The language of the audio file.
+
+#### Response
+
+- `transcription`: The transcribed text.
+- `json`: The transcription result in JSON format (for "Auto Transcribe" and "Diarisation" tasks).
+
+#### Example
+
+```bash
+curl -X POST "http://localhost:7860/api/transcribe" -F "file=@path/to/audio/file.wav" -F "task=Auto Transcribe" -F "num_speakers=2" -F "translate=false" -F "language=English"
+```
+
+### Running the API
+
+To run the API, use the following command:
+
+```bash
+uvicorn scraibe_webui.api:app --host 0.0.0.0 --port 8000
+```
+
+This will start the FastAPI server and expose the API endpoints at `http://localhost:8000/api/...`.

--- a/scraibe_webui/api.py
+++ b/scraibe_webui/api.py
@@ -1,0 +1,40 @@
+from fastapi import FastAPI, UploadFile, File, Form
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+from typing import List, Union
+from .utils.wrapper import ScraibeWrapper
+
+app = FastAPI()
+
+class TranscriptionRequest(BaseModel):
+    task: str
+    num_speakers: int = 0
+    translate: bool = False
+    language: str = "Unspecified"
+
+@app.post("/api/transcribe")
+async def transcribe_audio(file: UploadFile = File(...), task: str = Form(...), num_speakers: int = Form(0), translate: bool = Form(False), language: str = Form("Unspecified")):
+    scraibe_params = {
+        "whisper_model": "base",
+        "whisper_type": "whisper",
+        "dia_model": None,
+        "use_auth_token": None,
+        "device": "cpu",
+        "num_threads": 4
+    }
+    scraibe = ScraibeWrapper.load_from_dict(scraibe_params)
+    audio_path = f"/tmp/{file.filename}"
+    with open(audio_path, "wb") as audio_file:
+        audio_file.write(await file.read())
+    
+    if task == "Auto Transcribe":
+        result, out_str, out_json = scraibe.autotranscribe(audio_path, num_speakers, translate, language)
+        return JSONResponse(content={"transcription": out_str, "json": out_json})
+    elif task == "Transcribe":
+        result = scraibe.transcribe(audio_path, translate, language)
+        return JSONResponse(content={"transcription": result})
+    elif task == "Diarisation":
+        result = scraibe.diarisation(audio_path, num_speakers)
+        return JSONResponse(content={"json": result})
+    else:
+        return JSONResponse(content={"error": "Invalid task"}, status_code=400)

--- a/scraibe_webui/app.py
+++ b/scraibe_webui/app.py
@@ -1,5 +1,7 @@
 from .utils.appconfigloader import AppConfigLoader
 from .ui import gradio_Interface
+from fastapi import FastAPI
+from .api import app as api_app
 
 class App(AppConfigLoader):
     def __init__(self, config: str = None, **kwargs):
@@ -14,6 +16,8 @@ class App(AppConfigLoader):
                       respective section in `config.yaml`.
         """
         super(App, self).__init__(config, **kwargs)
+        self.api_app = FastAPI()
+        self.api_app.mount("/api", api_app)
 
     def start(self):
         """


### PR DESCRIPTION
Add a new API endpoint to bypass the front end and programmatically call the backend to get transcriptions.

* **New API File**: Add `scraibe_webui/api.py` to define the API endpoints using FastAPI.
  - Create a FastAPI app to handle transcription requests.
  - Define an endpoint to receive audio files and return transcriptions.
  - Use the existing `ScraibeWrapper` class to perform transcriptions.

* **App Integration**: Modify `scraibe_webui/app.py` to include the FastAPI app.
  - Import FastAPI and mount the new API app.
  - Update the `App` class to include the FastAPI app.

* **Dockerfile**: Update `Dockerfile` to install FastAPI and Uvicorn.
  - Install FastAPI and Uvicorn dependencies.

* **Documentation**: Update `README.md` to include instructions on how to use the new API endpoints.
  - Add details about the new API endpoints and how to use them.
  - Provide example requests and responses for the API.

